### PR TITLE
add `embedded-hal-async` driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 embedded-hal = "0.2.3"
+embedded-hal-async = { version = "0.2.0-alpha.2", optional = true }

--- a/src/async.rs
+++ b/src/async.rs
@@ -44,12 +44,8 @@ where
     pub async fn get_fifo_key_raw(&mut self) -> Result<KeyRaw, I2C::Error> {
         let mut buf = [0u8; 2];
 
-        self.i2c
-            .transaction(
-                KBD_ADDR,
-                &mut [Write(&[register::FIFO]), Read(&mut buf[..])],
-            )
-            .await?;
+        self.i2c.write(KBD_ADDR, &[register::FIFO]).await?;
+        self.i2c.read(KBD_ADDR, &mut buf[..]).await?;
 
         Ok(KeyRaw::from_bytes(buf))
     }
@@ -95,13 +91,8 @@ where
     pub async fn get_key_status(&mut self) -> Result<KeyStatus, I2C::Error> {
         let mut buf = [0u8; 1];
 
-        self.i2c
-            .transaction(
-                KBD_ADDR,
-                &mut [Write(&[register::KEY_STATUS]), Read(&mut buf[..])],
-            )
-            .await?;
-
+        self.i2c.write(KBD_ADDR, &[register::KEY_STATUS]).await?;
+        self.i2c.read(KBD_ADDR, &mut buf).await?;
         Ok(KeyStatus::from_byte(buf[0]))
     }
 }

--- a/src/async.rs
+++ b/src/async.rs
@@ -1,0 +1,107 @@
+use super::{register, KeyRaw, KeyStatus, Version, KBD_ADDR};
+use embedded_hal_async::i2c::{I2c, Operation::*};
+
+/// A struct representing an asynchronous driver for the BlackBerry Q10 PMOD
+/// Keyboard
+pub struct AsyncBbq10Kbd<I2C>
+where
+    I2C: I2c,
+{
+    i2c: I2C,
+}
+
+impl<I2C> AsyncBbq10Kbd<I2C>
+where
+    I2C: I2c,
+{
+    /// Create a new async BBQ10 Keyboard instance
+    #[must_use]
+    pub fn new(i2c: I2C) -> Self {
+        Self { i2c }
+    }
+
+    /// Consume self, returning the inner I2C device
+    #[must_use]
+    pub fn release(self) -> I2C {
+        self.i2c
+    }
+
+    /// Get the version reported by the keyboard's firmware
+    pub async fn get_version(&mut self) -> Result<Version, I2C::Error> {
+        let mut buf = [0u8; 1];
+
+        self.i2c
+            .transaction(
+                KBD_ADDR,
+                &mut [Write(&[register::VERSION]), Read(&mut buf[..])],
+            )
+            .await?;
+
+        Ok(Version::from_byte(buf[0]))
+    }
+
+    /// Obtain a single fifo item from the keyboard's firmware
+    pub async fn get_fifo_key_raw(&mut self) -> Result<KeyRaw, I2C::Error> {
+        let mut buf = [0u8; 2];
+
+        self.i2c
+            .transaction(
+                KBD_ADDR,
+                &mut [Write(&[register::FIFO]), Read(&mut buf[..])],
+            )
+            .await?;
+
+        Ok(KeyRaw::from_bytes(buf))
+    }
+
+    /// Get the current level of backlight. All u8 values are valid
+    pub async fn get_backlight(&mut self) -> Result<u8, I2C::Error> {
+        let mut buf = [0u8; 1];
+
+        self.i2c
+            .transaction(
+                KBD_ADDR,
+                &mut [Write(&[register::BACKLIGHT]), Read(&mut buf[..])],
+            )
+            .await?;
+
+        Ok(buf[0])
+    }
+
+    /// Set the current level of backlight. All u8 values are valid
+    pub async fn set_backlight(&mut self, level: u8) -> Result<(), I2C::Error> {
+        let mut buf = [0u8; 2];
+
+        buf[0] = register::BACKLIGHT | register::WRITE;
+        buf[1] = level;
+
+        self.i2c.write(KBD_ADDR, &buf).await
+    }
+
+    /// Reset the device via software
+    ///
+    /// WARNING: Device may take >= 10ms to reboot. It
+    /// will not be responsive during this time
+    pub async fn sw_reset(&mut self) -> Result<(), I2C::Error> {
+        let mut buf = [0u8; 1];
+
+        buf[0] = register::RESET;
+
+        // This is enough to reset the device
+        self.i2c.write(KBD_ADDR, &buf).await
+    }
+
+    /// Get the reported status of the keyboard
+    pub async fn get_key_status(&mut self) -> Result<KeyStatus, I2C::Error> {
+        let mut buf = [0u8; 1];
+
+        self.i2c
+            .transaction(
+                KBD_ADDR,
+                &mut [Write(&[register::KEY_STATUS]), Read(&mut buf[..])],
+            )
+            .await?;
+
+        Ok(KeyStatus::from_byte(buf[0]))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub struct Version {
 }
 
 /// A raw key event from the management FIFO
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum KeyRaw {
     Invalid,
     Pressed(u8),
@@ -61,7 +61,7 @@ pub enum KeyRaw {
 ///
 /// Numlock is enabled by pressing `alt` + `Left Shift`, and
 /// disabled by double clicking either Shift key
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum NumLockState {
     Off,
     On,
@@ -75,7 +75,7 @@ pub enum NumLockState {
 /// NOTE: Due to a firmware bug, the Fifo count may roll over
 /// into the CapsLock bit. In this case, an `Unknown` value will
 /// be returned.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CapsLockState {
     Off,
     On,
@@ -90,14 +90,15 @@ pub enum CapsLockState {
 /// into the CapsLock bit. In this case, an `EmptyOr32` value will
 /// be returned, and there are either zero or 32 elements in the
 /// fifo currently.
-#[derive(Debug)]
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FifoCount {
     Known(u8),
     EmptyOr32,
 }
 
 /// The current key status register reported by the keyboard firmware
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct KeyStatus {
     pub num_lock: NumLockState,
     pub caps_lock: CapsLockState,


### PR DESCRIPTION
This branch adds an `embedded-hal-async` version of the Blackberry Q10
keyboard driver. The async driver is basically identical to the blocking
driver, except its methods are async, and it returns the error type
defined by the `embedded-hal-async::i2c::I2c` trait.

Because `embedded-hal-async` depends on nightly Rust features, the async
driver is behind an off-by-default feature flag.

I've also done some refactoring to the main (blocking) driver so that
parts of it can be more easily reused with the async driver.

Closes tosc-rs/mnemos#144